### PR TITLE
Altered behavior of output builder, fixed minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ You can add builder function to a store description.
     	nameOfOperation: { //name of an operation on a store
         	_type: 'query',
         	// DocumentClient query goes here
-            _outputBuilder: function(result) { /* output building logic */ }
+            _outputBuilder: function(rawResult) { /* output building logic */ }
         }
     }
 }
@@ -219,7 +219,11 @@ You can add builder function to a store description.
 
 Output builder function gets called before returning data. It is useful to restructure data in the way application expects to receive it back.
 
-When used with paging and reducer, output builder function will be called after all paging and reducing is completed, right before returning results back.
+Output builder always receive raw database data.
+
+When used with paging and reducer, output builder function will be called before passing data to reducer. So reducer will aggregate built results in this case.
+
+Same rule applies to pageCallback, it will receive result returned by output builder for each page.
 
 ---
 ### Operation level table name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynochamber",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Write DynamoDB queries in declarative way",
   "main": "index.js",
   "scripts": {
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "sinon": "^1.17.6"
   }
 }

--- a/query-builder.js
+++ b/query-builder.js
@@ -43,7 +43,7 @@ queryBuilder._substitutePlaceholders = function(value, model) {
 };
 
 queryBuilder.cleanFromNonDynamoData = function(query) {
-  const nonDynamoFields = ["_type", "_validator", "_options"];
+  const nonDynamoFields = ["_type", "_validator", "_options", "_outputBuilder"];
   return _.omit(query, nonDynamoFields);
 };
 
@@ -68,9 +68,9 @@ queryBuilder.build = function(tableName, operationTemplate, model) {
   var buildDynamoQuery = _.flow(
     _.partialRight(queryBuilder._addTableName, table),
     _.partialRight(queryBuilder._addDynamoOperation, operationTemplate),
-    _.partialRight(queryBuilder.fillPlaceholders, model),
-
-    queryBuilder.cleanFromNonDynamoData);
+    queryBuilder.cleanFromNonDynamoData,
+    _.partialRight(queryBuilder.fillPlaceholders, model)
+    );
 
   var initialQuery = {};
   return buildDynamoQuery(initialQuery);


### PR DESCRIPTION
Change in behavior:
- raw option will always return raw data, even if output builder defined
- output builder always work with raw data and extract is ignored if output builder provided
- if output builder provided and reducer is used in a call, reducer will reduce results of outputbuilder
- if output builder provided and pageCallback is used in a call, pageCallback will be called with results of output builder

Bugfix:
- if paging operation fails, result should be null
- validation function executed twice in one call